### PR TITLE
Remove the locked version of sysrandom

### DIFF
--- a/fastlane-sirp.gemspec
+++ b/fastlane-sirp.gemspec
@@ -34,9 +34,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # See : https://bugs.ruby-lang.org/issues/9569
-  spec.add_runtime_dependency 'sysrandom', '~> 1.0'
-
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.4'

--- a/lib/fastlane-sirp.rb
+++ b/lib/fastlane-sirp.rb
@@ -1,6 +1,6 @@
 require 'openssl'
 require 'digest'
-require 'sysrandom/securerandom'
+require 'securerandom'
 require 'fastlane-sirp/sirp'
 require 'fastlane-sirp/parameters'
 require 'fastlane-sirp/client'


### PR DESCRIPTION
Currently this gem uses https://github.com/cryptosphere/sysrandom, which is a version of securerandom that has been dead since 2018. It seems to have been used as a workaround to this long running issue (from 2014) which looks to now be long resolved - https://bugs.ruby-lang.org/issues/9569

This is an issue for 2 reasons:
- Relying on unsupported gems might result in security issues (unlikely in something like this, but worth keeping in mind)
- It appears to overload SecureRandom, which breaks a bunch of other gems that rely on randomisation (this is my selfish case 🙂)

If applied this commit will remove this locked version and start relying on the ruby stdlib version of securerandom instead which is supported and relied on by other gems



**DISCLAIMER:** Unfortunately I'm not a security expert, so I could well be missing a detail on this. But as far as I can tell the issue referenced is long resolved.

I've managed to run this fork to be able to log in to ASC and collect review and app data successfully 