### PR TITLE
Rework coverage into simplecov - remove coveralls & coco.

### DIFF
--- a/.coco.yml
+++ b/.coco.yml
@@ -1,7 +1,0 @@
-:include:
-  - lib
-:exclude:
-  - spec
-  - lib/sirp/version.rb
-:theme: dark
-:show_link_in_terminal: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/fastlane-sirp.svg)](https://badge.fury.io/rb/fastlane-sirp)
 [![Test](https://github.com/fastlane/fastlane-sirp/actions/workflows/test.yml/badge.svg)](https://github.com/fastlane/fastlane-sirp/actions/workflows/test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/fastlane/fastlane-sirp/badge.svg?branch=master)](https://coveralls.io/github/grempe/sirp?branch=master)
 
 Ruby Docs : [http://www.rubydoc.info/gems/fastlane-sirp](http://www.rubydoc.info/gems/sirp)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'wwtd/tasks'
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/fastlane-sirp.gemspec
+++ b/fastlane-sirp.gemspec
@@ -38,7 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'pry', '~> 0.12'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
-  spec.add_development_dependency 'coco', '~> 0.15'
-  spec.add_development_dependency 'wwtd', '~> 1.3'
+  spec.add_development_dependency 'simplecov', '~> 0.22.0'
 end

--- a/spec/authentication_spec.rb
+++ b/spec/authentication_spec.rb
@@ -152,13 +152,13 @@ describe SIRP do
       x = verifier.calc_x_hex(xpassword, salt, verifier.hash)
       v_hex = verifier.num_to_hex(verifier.calc_v(x, verifier.N, verifier.g))
 
-      # phase 1 (client)
+      # P1 : client
       aa = client.start_authentication
 
-      # phase 1 (server) with encrypted-registration verifier
+      # P1 : (server) with encrypted-registration verifier
       cp = verifier.get_challenge_and_proof(@username, v_hex, salt, aa)
 
-      # phase 2 (client) using encrypted password path
+      # P2 : (client) using encrypted password path
       client_M = client.process_challenge(@username, xpassword, salt, cp[:proof][:B], is_password_encrypted: true)
 
       # client computed values are present
@@ -167,7 +167,7 @@ describe SIRP do
       expect(client.K).to be_truthy
       expect(client.H_AMK).to be_truthy
 
-      # phase 2 (server) — should succeed because server verifier matches encrypted mode
+      # P2 : (server) — should succeed because server verifier matches encrypted mode
       proof = { A: aa, B: cp[:proof][:B], b: cp[:proof][:b], I: @username, s: salt, v: v_hex }
       server_H_AMK = verifier.verify_session(proof, client_M)
       expect(server_H_AMK).to be_truthy

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,8 @@
 # encoding: utf-8
 
-# coveralls.io and coco are incompatible. Run each in their own env.
-if ENV['TRAVIS'] || ENV['CI'] || ENV['JENKINS_URL'] || ENV['TDDIUM'] || ENV['COVERALLS_RUN_LOCALLY']
-  # coveralls.io : web based code coverage
-  require 'coveralls'
-  Coveralls.wear!
-else
-  # coco : local code coverage
-  require 'fileutils'
-  require 'coco'
-end
+require 'simplecov'
+SimpleCov.start
+SimpleCov.minimum_coverage 100
 
 require 'fastlane-sirp'
 


### PR DESCRIPTION
Previously this project used coco locally and coveralls (with simplecov) on CI. Two distinct coverage systems is rough and since the fork didn't maintain a _fastlane_ driven coveralls - it didn't seem worth it to keep.

This unifies to simplecov and does a few things

 * Removes wwtd as it was for matrix testing on TravisCI - we do this via GitHub Actions
 * It enforces 100% code coverage. 100% was broken on [this commit](https://github.com/fastlane/fastlane-sirp/commit/37a78ed7e9744b8bfe66e2c3f13e1169bf7e1388) so I added a test to recover that line.

---

There are 0 user-land changes. This is entirely test changes.