### PR TITLE
build: skip changes to .bundle/config during publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Ignore changes to .bundle/config
+        run: git update-index --skip-worktree .bundle/config
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: 3.2
 
-      - name: Install dependencies
-        run: bundle check || bundle install --jobs=4 --retry=3
+      - name: Debug git status
+        run: |
+          git status
+          git status --porcelain
 
       - uses: rubygems/release-gem@v1


### PR DESCRIPTION
This ports the changes from [fastlane-community/xcov](https://github.com/fastlane-community/xcov/pull/233#issuecomment-3552807057) that we saw during the wired up Trusted Publishing.